### PR TITLE
Update `jest` dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "eslint-plugin-node": "^6.0.1",
     "eslint-plugin-promise": "^3.7.0",
     "eslint-plugin-standard": "^3.0.1",
-    "jest": "^22.4.3",
+    "jest": "^23.6.0",
     "react": "^16.3.1",
     "react-dom": "^16.3.1"
   },


### PR DESCRIPTION
Tests were failing on my machine. Appears the problem was caused by `jest`'s dependency `jsdoc` including an change on a minor release which broke jest. https://github.com/jsdom/jsdom/issues/2304

Updating jest to 23.x.x seems to fix it.