### PR TITLE
Support new Context API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 node_modules
 .idea
 index.js
+server.js
 !src/index.js
+!src/server.js
 coverage

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "repository": "https://github.com/zekchan/react-ssr-error-boundary",
   "scripts": {
-    "build": "babel src/index.js > index.js",
+    "build": "babel src --out-dir . --ignore '*.test.js'",
     "test": "jest",
     "prepublish": "npm run build"
   },

--- a/src/client.test.js
+++ b/src/client.test.js
@@ -94,4 +94,116 @@ describe('Client side', () => {
 
     expect(component.html()).toBe('<div><div>No errors! Context variable</div></div>')
   })
+
+  it('Renders child component with new context dependencies', () => {
+    const Context = React.createContext()
+
+    function GoodComponent () {
+      return (
+        <Context.Consumer>
+          {context => <div>No errors! {context.someContext}</div>}
+        </Context.Consumer>
+      )
+    }
+
+    function ContextProvider (props) {
+      return (
+        <Context.Provider value={{someContext: 'Context variable'}}>
+          {props.children}
+        </Context.Provider>
+      )
+    }
+
+    const component = mount(
+      <ContextProvider>
+        <ErrorFallback fallBack={() => <FallBack />}>
+          <GoodComponent />
+        </ErrorFallback>
+      </ContextProvider>
+    )
+
+    expect(component.html()).toBe('<div><div>No errors! Context variable</div></div>')
+  })
+
+  it('Renders child component with multiple new context dependencies', () => {
+    const Context1 = React.createContext()
+    const Context2 = React.createContext()
+    const Context3 = React.createContext()
+
+    function GoodComponent () {
+      return (
+        <Context1.Consumer>
+          {context1 => (
+              <Context2.Consumer>
+                {context2 => (
+                    <Context3.Consumer>
+                      {context3 => (
+                          <div>No errors! {context1.someContext} {context2.someContext} {context3.someContext}</div>
+                      )}
+                    </Context3.Consumer>
+                )}
+              </Context2.Consumer>
+          )}
+        </Context1.Consumer>
+      )
+    }
+
+    function ContextProvider (props) {
+      return (
+        <Context1.Provider value={{someContext: 'Context variable1'}}>
+          <Context2.Provider value={{someContext: 'Context variable2'}}>
+            <Context3.Provider value={{someContext: 'Context variable3'}}>
+              {props.children}
+            </Context3.Provider>
+          </Context2.Provider>
+        </Context1.Provider>
+      )
+    }
+
+    const component = mount(
+      <ContextProvider>
+        <ErrorFallback fallBack={() => <FallBack />}>
+          <GoodComponent />
+        </ErrorFallback>
+      </ContextProvider>
+    )
+
+    expect(component.html()).toBe('<div><div>No errors! Context variable1 Context variable2 Context variable3</div></div>')
+  })
+
+  it('Renders fallBack component if children rendering throws error with new contexts', () => {
+    const Context = React.createContext()
+
+    function BadComponent () {
+      return (
+        <Context.Consumer>
+          {() => <BadComponentInner/>}
+        </Context.Consumer>
+      )
+    }
+
+    function BadComponentInner () {
+      throw new Error()
+    }
+
+    function ContextProvider (props) {
+      return (
+        <Context.Provider value={{someContext: 'Context variable'}}>
+          {props.children}
+        </Context.Provider>
+      )
+    }
+
+    turnOffErrors()
+    const component = mount(
+      <ContextProvider>
+        <ErrorFallback fallBack={() => <FallBack />}>
+          <BadComponent />
+        </ErrorFallback>
+      </ContextProvider>
+    )
+
+    expect(component.html()).toBe('<div><div>FallBack!</div></div>')
+    turnOnErrors()
+  })
 })

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ import React, { Component } from 'react'
 const server = typeof window === 'undefined' && require('./server')
 
 export function withContext (contextTypes = {}) {
-  const ProvideContext = server && server.makeProvider(contextTypes)
+  const ProvideContext = server && server._makeProvider(contextTypes)
 
   class ServerBoundary extends Component {
     static defaultProps = {
@@ -21,7 +21,7 @@ export function withContext (contextTypes = {}) {
     }
 
     render () {
-      if (server) return server.render(this, ProvideContext)
+      if (server) return server._render(this, ProvideContext)
       return <div>{this.state.elementToRender}</div>
     }
   }

--- a/src/index.js
+++ b/src/index.js
@@ -1,19 +1,9 @@
 import React, { Component } from 'react'
 
-const isServer = typeof window === 'undefined'
+const server = typeof window === 'undefined' && require('./server')
 
 export function withContext (contextTypes = {}) {
-  class ProvideContext extends Component {
-    static childContextTypes = contextTypes
-
-    getChildContext () {
-      return this.props.context
-    }
-
-    render () {
-      return this.props.children
-    }
-  }
+  const ProvideContext = server && server.makeProvider(contextTypes)
 
   class ServerBoundary extends Component {
     static defaultProps = {
@@ -31,19 +21,7 @@ export function withContext (contextTypes = {}) {
     }
 
     render () {
-      if (isServer) {
-        try {
-          const __html = require('react-dom/server').renderToStaticMarkup(
-            <ProvideContext context={this.context}>
-              {this.props.children}
-            </ProvideContext>
-          )
-          return <div dangerouslySetInnerHTML={{__html}} />
-        } catch (e) {
-          return <div>{this.props.fallBack()}</div>
-        }
-      }
-
+      if (server) return server.render(this, ProvideContext)
       return <div>{this.state.elementToRender}</div>
     }
   }

--- a/src/server.js
+++ b/src/server.js
@@ -1,7 +1,36 @@
 import React, { Component } from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
 
-export function makeProvider (contextTypes) {
+// Array to store React contexts
+const contexts = []
+
+// Use specific context
+export function useContext (Context) {
+  contexts.push(Context);
+}
+
+// Clear contexts in use
+export function clearContexts () {
+  contexts.length = 0
+}
+
+// Shim `React.createContext()` to capture contexts
+let shimmed = false
+
+export function shim () {
+  if (shimmed) return
+  shimmed = true
+
+  const { createContext } = React
+  React.createContext = function() {
+    const Context = createContext.apply(this, arguments)
+    contexts.push(Context)
+    return Context
+  }
+}
+
+// Create Provider component for specific context types
+export function _makeProvider (contextTypes) {
   return class ProvideContext extends Component {
     static childContextTypes = contextTypes
 
@@ -15,15 +44,65 @@ export function makeProvider (contextTypes) {
   }
 }
 
-export function render (self, ProvideContext) {
-  try {
-    const __html = renderToStaticMarkup(
-      <ProvideContext context={self.context}>
-        {self.props.children}
-      </ProvideContext>
+// Server-side render, propagating contexts to children
+export function _render (self, ProvideContext) {
+  // Wrap element in provider for legacy context
+  const element = (
+    <ProvideContext context={self.context}>
+      {self.props.children}
+    </ProvideContext>
+  )
+
+  // Wrap element in consumers and providers for new context.
+  // Consumers are added outside HTML render, to capture value of all contexts.
+  // Providers are added inside HTML render, to reinject context values back
+  // into the rendered element.
+  return stackConsumers(values => {
+    const elementWithProviders = stackProviders(element, values)
+
+    try {
+      const __html = renderToStaticMarkup(elementWithProviders)
+      return <div dangerouslySetInnerHTML={{__html}} />
+    } catch (e) {
+      return <div>{self.props.fallBack()}</div>
+    }
+  })
+}
+
+// Create stack of consumer components
+function stackConsumers (retFn) {
+  const values = []
+  let fn = () => retFn(values)
+
+  for (let i = 0; i < contexts.length; i++) {
+    const Context = contexts[i]
+    const childFn = fn
+
+    fn = () => (
+      <Context.Consumer>
+        {value => {
+          values[i] = value
+          return childFn()
+        }}
+      </Context.Consumer>
     )
-    return <div dangerouslySetInnerHTML={{__html}} />
-  } catch (e) {
-    return <div>{self.props.fallBack()}</div>
   }
+
+  return fn()
+}
+
+// Create stack of provider components
+function stackProviders (element, values) {
+  for (let i = 0; i < values.length; i++) {
+    const Context = contexts[i]
+    const childElement = element
+
+    element = (
+      <Context.Provider value={values[i]}>
+        {childElement}
+      </Context.Provider>
+    )
+  }
+
+  return element
 }

--- a/src/server.js
+++ b/src/server.js
@@ -1,0 +1,29 @@
+import React, { Component } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+
+export function makeProvider (contextTypes) {
+  return class ProvideContext extends Component {
+    static childContextTypes = contextTypes
+
+    getChildContext () {
+      return this.props.context
+    }
+
+    render () {
+      return this.props.children
+    }
+  }
+}
+
+export function render (self, ProvideContext) {
+  try {
+    const __html = renderToStaticMarkup(
+      <ProvideContext context={self.context}>
+        {self.props.children}
+      </ProvideContext>
+    )
+    return <div dangerouslySetInnerHTML={{__html}} />
+  } catch (e) {
+    return <div>{self.props.fallBack()}</div>
+  }
+}


### PR DESCRIPTION
This PR is my first stab at a solution to #2, supporting React's new Context API which is what React Router etc use.

I've succeeded in making it automatic - you don't need to declare the contexts in use. But that comes at the cost of monkey-patching React's `.createContext()` method to record all contexts in use. To activate the shim which makes it work, you need to do `require('react-ssr-error-boundary/server').shim()`.

Alternatively, contexts can be added manually with `require('react-ssr-error-boundary/server').useContext()`.

It needs some tidying up and I'd intend to write more tests, but is this PR something you'd consider merging?